### PR TITLE
IPT-31: changing integreatly naming refs for RHI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,85 @@
+.idea
+.DS_Store
+# Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+# Org-mode
+.org-id-locations
+*_archive
+# flymake-mode
+*_flymake.*
+# eshell files
+/eshell/history
+/eshell/lastdir
+# elpa packages
+/elpa/
+# reftex files
+*.rel
+# AUCTeX auto folder
+/auto/
+# cask packages
+.cask/
+dist/
+# Flycheck
+flycheck_*.el
+# server auth directory
+/server/
+# projectiles files
+.projectile
+projectile-bookmarks.eld
+# directory configuration
+.dir-locals.el
+# saveplace
+places
+# url cache
+url/cache/
+# cedet
+ede-projects.el
+# smex
+smex-items
+# company-statistics
+company-statistics-cache.el
+# anaconda-mode
+anaconda-mode/
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binary, build with 'go test -c'
+*.test
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+*.out.tmp
+### Vim ###
+# swap
+.sw[a-p]
+.*.sw[a-p]
+# session
+Session.vim
+# temporary
+.netrwhist
+# auto-generated tag files
+tags
+### VisualStudioCode ###
+.vscode/*
+.history
+# End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+deploy/integreatly-rhmi-cr.yml
+#ocm generated templates
+ocm/
+htpasswd
+
 # Ignore the test binary
-integreatly-operator-test-harness.test
+rhi-operator-test-harness.test
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 
-ENV PKG=/go/src/github.com/integr8ly/integreatly-operator-test-harness/
+ENV PKG=/go/src/github.com/redhat-integration/rhi-operator-test-harness/
 WORKDIR ${PKG}
 
 # compile test binary
@@ -9,7 +9,7 @@ RUN make
 
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
-COPY --from=builder /go/src/github.com/integr8ly/integreatly-operator-test-harness/integreatly-operator-test-harness.test integreatly-operator-test-harness.test
+COPY --from=builder /go/src/github.com/redhat-integration/rhi-operator-test-harness/rhi-operator-test-harness.test rhi-operator-test-harness.test
 
-ENTRYPOINT [ "/integreatly-operator-test-harness.test" ]
+ENTRYPOINT [ "/rhi-operator-test-harness.test" ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-OUT_FILE := "$(DIR)integreatly-operator-test-harness"
+OUT_FILE := "$(DIR)rhi-operator-test-harness"
 
 build:
 	CGO_ENABLED=0 go test -v -c

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# integreatly-operator-test-harness
+# rhi-operator-test-harness
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/integr8ly/integreatly-operator-test-harness
+module github.com/redhat-integration/rhi-operator-test-harness
 
 go 1.13
 

--- a/pkg/tests/rhi_operator_tests.go
+++ b/pkg/tests/rhi_operator_tests.go
@@ -1,15 +1,15 @@
 package tests
 
 import (
+	"github.com/redhat-integration/rhi-operator-test-harness/pkg/metadata"
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/integr8ly/integreatly-operator-test-harness/pkg/metadata"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 )
 
-var _ = ginkgo.Describe("Integreatly Operator Tests", func() {
+var _ = ginkgo.Describe("RHI Operator Tests", func() {
 	defer ginkgo.GinkgoRecover()
 	config, err := rest.InClusterConfig()
 

--- a/rhi_operator_test_harness_suite_test.go
+++ b/rhi_operator_test_harness_suite_test.go
@@ -1,4 +1,4 @@
-package integreatly_operator_test_harness
+package rhi_operator_test_harness
 
 import (
 	"path/filepath"
@@ -7,22 +7,22 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
-	"github.com/integr8ly/integreatly-operator-test-harness/pkg/metadata"
+	"github.com/redhat-integration/rhi-operator-test-harness/pkg/metadata"
 
-	_ "github.com/integr8ly/integreatly-operator-test-harness/pkg/tests"
+	_ "github.com/redhat-integration/rhi-operator-test-harness/pkg/tests"
 )
 
 const (
 	testResultsDirectory = "/test-run-results"
-	jUnitOutputFilename  = "junit-integreatly-operator.xml"
+	jUnitOutputFilename  = "junit-rhi-operator.xml"
 	addonMetadataName    = "addon-metadata.json"
 )
 
-func TestIntegreatlyOperatorTestHarness(t *testing.T) {
+func TestRHIOperatorTestHarness(t *testing.T) {
 	RegisterFailHandler(Fail)
 	jUnitReporter := reporters.NewJUnitReporter(filepath.Join(testResultsDirectory, jUnitOutputFilename))
 
-	RunSpecsWithDefaultAndCustomReporters(t, "Integreatly Operator Test Harness", []Reporter{jUnitReporter})
+	RunSpecsWithDefaultAndCustomReporters(t, "RHI Operator Test Harness", []Reporter{jUnitReporter})
 
 	err := metadata.Instance.WriteToJSON(filepath.Join(testResultsDirectory, addonMetadataName))
 	if err != nil {


### PR DESCRIPTION
Changing name references.  Excludes CRD "name" in rhi_operator_tests intentionally, as this will need to be modified once rhi-operator has a new API version committed.